### PR TITLE
refactor: e-mail destinatário individual é removido do store

### DIFF
--- a/frontend/src/pages/EmailAdmin/EmailAdmin.vue
+++ b/frontend/src/pages/EmailAdmin/EmailAdmin.vue
@@ -313,15 +313,15 @@ async function fetchUpdateEmail () {
   //   form.value?.setFieldValue('escopo', jsonEmail.escopo)
   // }
 
-  const message = `Prezado(a) [nome do aluno],
+  const message = `Prezado(a),
 
   Espero que esta mensagem o encontre bem. Gostaríamos de lembrá-lo(a) da importância de manter seu cadastro atualizado em nosso portal Meu Egresso.
 
   Para garantir que possamos manter contato com você e fornecer informações importantes sobre eventos, oportunidades de emprego, cursos e outros escopos relevantes, solicitamos que atualize suas informações pessoais e profissionais.
 
-  Pedimos que acesse o portal Meu Egresso (link) e faça login com suas credenciais. Em seguida, atualize suas informações no seu perfil.
+  Pedimos que acesse o portal Meu Egresso (https://egressos.computacao.ufpa.br/) e faça login com suas credenciais. Em seguida, atualize suas informações no seu perfil.
 
-  Caso tenha alguma dificuldade para acessar o portal ou atualizar suas informações, entre em contato conosco pelo e-mail (e-mail) ou telefone (número). Teremos o maior prazer em ajudá-lo(a).
+  Caso tenha alguma dificuldade para acessar o portal ou atualizar suas informações, entre em contato conosco pelo e-mail egressocomp@ufpa.br ou pelo telefone 3201-7405 (Faculdade de Computação). Teremos o maior prazer em ajudá-lo(a).
 
   Agradecemos antecipadamente pela sua colaboração em manter suas informações atualizadas. Isso nos ajuda a manter contato com você e oferecer um serviço mais eficiente e personalizado.
 

--- a/frontend/src/pages/PainelAdmin/PainelAdmin.vue
+++ b/frontend/src/pages/PainelAdmin/PainelAdmin.vue
@@ -141,29 +141,28 @@
               />
             </RouterLink>
           </div>
-          <div class="border-b text-cyan-600 p-4 font-semibold text-left">
-            <RouterLink
-              to="/email"
-              class="flex items-center"
-            >
-              <SvgIcon
-                type="mdi"
-                size="20"
-                class="inline mr-2"
-                :path="mdiEmail"
-              />
+          <div
+            role="button"
+            class="flex items-center border-b text-cyan-600 p-4 font-semibold text-left"
+            @click="navigateToEmailSettings"
+          >
+            <SvgIcon
+              type="mdi"
+              size="20"
+              class="inline mr-2"
+              :path="mdiEmail"
+            />
 
-              Configurar e-mail de atualização
+            Configurar e-mail de atualização
 
-              <div class="flex-1" />
+            <div class="flex-1" />
 
-              <SvgIcon
-                type="mdi"
-                size="20"
-                class="inline"
-                :path="mdiChevronRight"
-              />
-            </RouterLink>
+            <SvgIcon
+              type="mdi"
+              size="20"
+              class="inline"
+              :path="mdiChevronRight"
+            />
           </div>
           <div class="border-b text-cyan-600 p-4 font-semibold text-left">
             <button @click="$painelStore.getPdf()">
@@ -403,6 +402,11 @@ const imageFlags = ref(new Map())
 async function logout () {
   $loginStore.userLogout()
   await $router.push('/entrar')
+}
+
+function navigateToEmailSettings () {
+  $router.push('/email')
+  $painelStore.setEgressoEmail(null)
 }
 
 type clickedTypes = keyof typeof selected.value

--- a/frontend/src/store/PainelStore.ts
+++ b/frontend/src/store/PainelStore.ts
@@ -11,7 +11,7 @@ interface State {
     mes: any[]
     ano: any[]
   }
-  sendToEmail: string
+  sendToEmail: string | null
 }
 
 export const usePainelStore = defineStore('Painel', {
@@ -133,7 +133,7 @@ export const usePainelStore = defineStore('Painel', {
       return response?.status != null ? response.status : 500
     },
 
-    setEgressoEmail (email: string) {
+    setEgressoEmail (email: string | null) {
       this.sendToEmail = email
     },
 


### PR DESCRIPTION
O e-mail escolhido para ser enviado para um egresso individualmente é removido do store ao selecionar a opção de atualizar a configuração do e-mail para todos os egressos no painel do admin.